### PR TITLE
Update discord validation to allow prefixing @

### DIFF
--- a/src/forms/hacker-form/validations.ts
+++ b/src/forms/hacker-form/validations.ts
@@ -78,12 +78,11 @@ export const validations: {
 				.string()
 				.nonempty("Discord username is empty")
 				.refine((val) => {
-					// expects user#1234 or usernmae (no spaces or invalid chars)
-					if (!/\#\d{4}$/.test(val) && !/^[a-zA-Z0-9_.]{2,32}$/.test(val)) {
-						return false;
-					}
-					return true;
-				}, "Invalid Discord username. Expected username or username#1234.")
+					// expects user#1234 or username or @username (no spaces or invalid chars)
+					return /^(@[a-zA-Z0-9_.]{2,32}|[a-zA-Z0-9_.]{2,32}(#\d{4})?)$/.test(
+						val,
+					);
+				}, "Invalid Discord username. Expected username or @username or username#1234.")
 				.safeParse(v),
 		),
 	major: (v) =>


### PR DESCRIPTION
## Description
This PR updates the regex that matches discord username and allows an optional `@` as a prefix or not at all.

## Linked Issues
- Fixes #71 

## Testing
- Test validating different discord username formats

## Reviewer Checklist
When reviewing this PR, make sure to keep the following in mind:
- This PR should not span too many unrelated tickets or changes.
  - If it does, consider breaking it up into smaller PRs.
- Is the code coverage acceptable?
- Does the preview deployment work as expected?
- Does this PR pass all tests?
- Does this PR have a clear list of issues that it closes?
- Does the code follow the style guidelines of the project?

## Author Checklist
Before opening this PR, make sure the PR:
- [x] Has an **assignee or group of assignees**.
- [x] Has a **reviewer or a group of reviewers**.
- [x] Is **labelled properly**.
- [x] Has an **assigned milestone**.
