### PR TITLE
fix hasApplied access check wrongly returning a true value

### DIFF
--- a/src/providers/RoutesProvider/accessChecks.ts
+++ b/src/providers/RoutesProvider/accessChecks.ts
@@ -33,10 +33,10 @@ export const isAdmin: AccessControlFn = (ctx) => {
  */
 export const hasApplied: AccessControlFn = (ctx) => {
 	if (ctx.applicationsCtx.applications.length < 1) return false;
-	const app = ctx.applicationsCtx.applications.find(
+	const idx = ctx.applicationsCtx.applications.findIndex(
 		(app) => app.hackathonYear === "2025",
 	);
-	return app?.applicationStatus === "pending";
+	return idx !== -1;
 };
 
 /**


### PR DESCRIPTION
## Description
Fix the access check `hasApplied` returning a false positive when application status is not `pending` but exists in database.

## Linked Issues
- Fixes #73 

## Testing
- Submit a new application
- change the application status to be something else other than `pending`
- The application page should not be accessible.

## Reviewer Checklist
When reviewing this PR, make sure to keep the following in mind:
- This PR should not span too many unrelated tickets or changes.
  - If it does, consider breaking it up into smaller PRs.
- Is the code coverage acceptable?
- Does the preview deployment work as expected?
- Does this PR pass all tests?
- Does this PR have a clear list of issues that it closes?
- Does the code follow the style guidelines of the project?

## Author Checklist
Before opening this PR, make sure the PR:
- [x] Has an **assignee or group of assignees**.
- [x] Has a **reviewer or a group of reviewers**.
- [x] Is **labelled properly**.
- [x] Has an **assigned milestone**.
